### PR TITLE
Fixing deprecation/warning usage :

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -416,7 +416,7 @@ module SPARQL
         begin
           graph = graph.to_s
           graph = "sparql:graph:#{graph}" unless graph.start_with?("sparql:graph:")
-          if @redis_cache.exists(graph)
+          if @redis_cache.exists?(graph)
             begin
               @redis_cache.del(graph)
             rescue => exception


### PR DESCRIPTION
For issue #3
Redis#exists(key) will return an Integer in redis-rb 4.3. exists? returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer = true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set Redis.exists_returns_integer = false, but this option will be removed in 5.0.