### PR TITLE
Add optional unions with bind query clause

### DIFF
--- a/lib/sparql/client/query.rb
+++ b/lib/sparql/client/query.rb
@@ -442,16 +442,15 @@ module SPARQL; class Client
           end
         end
         if options[:unions_with_bind]
-          include_union = nil
-          options[:unions_with_bind].each do |union_block, value_bind, var_bind|
-            buffer << include_union if include_union
-            buffer << '{'
-            buffer += serialize_patterns(union_block)
-            buffer << "BIND (\"#{value_bind}\" as ?#{var_bind.to_s})"
-            buffer << '}'
-            include_union = "UNION "
-          end
+          buffer <<  add_union_with_bind(options[:unions_with_bind])
         end
+
+        if options[:optional_unions_with_bind] && !options[:optional_unions_with_bind].empty?
+          buffer << 'OPTIONAL {'
+          buffer <<  add_union_with_bind(options[:optional_unions_with_bind])
+          buffer << '}'
+        end
+
         if options[:optionals]
           options[:optionals].each do |patterns|
             buffer << 'OPTIONAL {'


### PR DESCRIPTION

Used for https://github.com/ncbo/goo/pull/124
To have this  sort of query 
```SPARQL
OPTIONAL {
   { ?id <attribute_1_uri> ?attributeObject . BIND("var_1" as ?attributeProperty) } 
  UNION	
    ....
    UNION
   { ?attributeObject <attribute_j_uri> ?id . BIND( "var_j" as ?attributeProperty)} # if attribute_j_uri is an inverse attribute 
   UNION 
     ....
   { ?id <attribute_n_uri> ?attributeObject . BIND("var_n" as ?attributeProperty) } 
}
```