### PR TITLE
Remove dead :unions_with_bind render branch

### DIFF
--- a/lib/sparql/client/query.rb
+++ b/lib/sparql/client/query.rb
@@ -843,12 +843,6 @@ class SPARQL::Client
 
 
 
-      if options[:unions_with_bind]
-        buffer.pop # remove } of where
-        buffer << add_union_with_bind(options[:unions_with_bind])
-        buffer << '}'
-      end
-
       if options[:optional_unions_with_bind] && !options[:optional_unions_with_bind].empty?
         buffer.pop # remove } of where
         buffer << 'OPTIONAL {'


### PR DESCRIPTION
## What

Removes the unreachable `:unions_with_bind` (non-optional) render branch from `Query#to_s` in `lib/sparql/client/query.rb`.

## Why

The branch was dead code. Its DSL writer (`union_with_bind_as`) was dropped during an earlier reset-to-upstream + manual reapply of NCBO customizations, which kept `optional_union_with_bind_as` but dropped the inline setter — leaving the render branch orphaned with no way to populate `options[:unions_with_bind]`. A dead branch that still looks functional is a maintenance trap.

## Scope / safety

- **Pure dead-code removal** — `options[:unions_with_bind]` has no writer in any active lineage, so no query the stack emits can reach this branch. Query output is unchanged.
- Verified unused across all active downstream consumers: `ncbo/goo`, `ontoportal/goo`, and the AgroPortal/LIRMM `ontoportal-lirmm-development` branch all call **only** `optional_union_with_bind_as`.
- **Retained:** the live `:optional_unions_with_bind` path and the shared `add_union_with_bind` helper it depends on.

## Not in scope (deliberately deferred)

The escaping hardening (route `add_union_with_bind` interpolation through `serialize_uri`/`serialize_value`) and the `buffer.pop` guard touch the **live** optional path and should land as a separate change with its own test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)